### PR TITLE
feat(plugin-segment): add anonymousId to track message if exists

### DIFF
--- a/packages/plugin-segment/src/androidMain/kotlin/ly.iterative.itly.segment/SegmentPlugin.kt
+++ b/packages/plugin-segment/src/androidMain/kotlin/ly.iterative.itly.segment/SegmentPlugin.kt
@@ -11,6 +11,7 @@ typealias SegmentProperties = com.segment.analytics.Properties
 
 actual class SegmentPlugin actual constructor(
     private val writeKey: String,
+    private val anonymousId: String,
     options: SegmentOptions
 ) : Plugin(ID) {
     companion object {

--- a/packages/plugin-segment/src/commonMain/kotlin/ly.iterative.itly.segment/SegmentPlugin.kt
+++ b/packages/plugin-segment/src/commonMain/kotlin/ly.iterative.itly.segment/SegmentPlugin.kt
@@ -2,5 +2,6 @@ package ly.iterative.itly.segment
 
 expect class SegmentPlugin(
     writeKey: String,
+    anonymousId: String = "",
     options: SegmentOptions
 )

--- a/packages/plugin-segment/src/jvmMain/kotlin/ly.iterative.itly.segment/SegmentPlugin.kt
+++ b/packages/plugin-segment/src/jvmMain/kotlin/ly.iterative.itly.segment/SegmentPlugin.kt
@@ -14,6 +14,7 @@ import kotlin.collections.HashMap
 
 actual class SegmentPlugin actual constructor(
     private val writeKey: String,
+    private val anonymousId: String,
     options: SegmentOptions
 ) : Plugin(ID) {
     companion object {
@@ -28,7 +29,8 @@ actual class SegmentPlugin actual constructor(
     val client: Analytics
         get() = this.segment
 
-    constructor(writeKey: String): this(writeKey, SegmentOptions())
+    constructor(writeKey: String): this(writeKey, "", SegmentOptions())
+    constructor(writeKey: String, options: SegmentOptions): this(writeKey, "", options)
 
     override fun load(options: PluginLoadOptions) {
         logger = options.logger
@@ -65,9 +67,12 @@ actual class SegmentPlugin actual constructor(
     }
 
     override fun track(userId: String?, event: Event) {
-        logger.info("[plugin-segment-jvm] track(userId=$userId, event=${event.name}, properties=${event.properties})")
+        logger.info("[plugin-segment-jvm] track(userId=$userId, anonymousId=$anonymousId, event=${event.name}, properties=${event.properties})")
         val properties = HashMap(event.properties)
         val message = TrackMessage.builder(event.name).userId(userId)
+        if (anonymousId.isNotEmpty()) {
+            message.anonymousId(anonymousId)
+        }
         if (properties.isNotEmpty()) {
             message.properties(properties)
         }

--- a/packages/plugin-segment/src/jvmTest/kotlin/ly/iterative/itly/segment/SegmentPluginJvmTest.kt
+++ b/packages/plugin-segment/src/jvmTest/kotlin/ly/iterative/itly/segment/SegmentPluginJvmTest.kt
@@ -17,4 +17,10 @@ class SegmentPluginTest {
         val segmentPlugin = SegmentPlugin("write-key", SegmentOptions())
         Assertions.assertNotNull(segmentPlugin)
     }
+
+    @Test
+    fun SegmentPluginJvm_instantiationWithAnonymousIdAndSegmentOptions_succeeds() {
+        val segmentPlugin = SegmentPlugin("write-key", "", SegmentOptions())
+        Assertions.assertNotNull(segmentPlugin)
+    }
 }


### PR DESCRIPTION
This PR allows to specify `anonymousId` for SegmentPlugin.
This will allow to set anonymousId for Segment `TrackMessage`, use empty `userId` and fix an issue with alias call.

This approach is similar to JavaScript Segment integration in Iteratively.